### PR TITLE
Portuguese (Brazil) translation

### DIFF
--- a/src/main/resources/assets/capes/lang/pt_br.json
+++ b/src/main/resources/assets/capes/lang/pt_br.json
@@ -1,0 +1,5 @@
+{
+  "options.capes.title": "Opções de Capa",
+  "options.capes.capetype": "Tipo de Capa: %s",
+  "options.capes.glint": "Brilho"
+}


### PR DESCRIPTION
This PR adds Portuguese (Brazil) translations to Capes.