### PR TITLE
Update to 1.18.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,8 +28,8 @@ operator fun Project.get(property: String): String {
 }
 
 configure<JavaPluginConvention> {
-    sourceCompatibility = JavaVersion.VERSION_16
-    targetCompatibility = JavaVersion.VERSION_16
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 version = project["mod_version"]
@@ -69,8 +69,8 @@ repositories {
 		url = uri("https://jitpack.io")
 	}
     maven {
-        name = "Ladysnake Libs"
-        url = uri("https://ladysnake.jfrog.io/artifactory/mods")
+        name = "Shedaniel Libs"
+        url = uri("https://maven.shedaniel.me/")
     }
     maven {
         name = "TerraformersMC"
@@ -86,11 +86,7 @@ dependencies {
     modImplementation("net.fabricmc:fabric-loader:${project["loader_version"]}")
     modImplementation("net.fabricmc.fabric-api:fabric-api:${project["fabric_version"]}")
     modImplementation("net.fabricmc:fabric-language-kotlin:${project["fabric_kotlin_version"]}")
-
-    modApi("me.sargunvohra.mcmods:autoconfig1u:${project["autoconfig_version"]}") {
-        exclude(group = "net.fabricmc.fabric-api")
-    }
-    include("me.sargunvohra.mcmods:autoconfig1u:${project["autoconfig_version"]}")
+    modImplementation("me.shedaniel.cloth:cloth-config-fabric:${project["cloth_version"]}")
 
     // Compatibility
     modImplementation("com.terraformersmc:modmenu:${project["modmenu_version"]}")
@@ -160,9 +156,9 @@ curseforge {
         mainArtifact(file(releaseFile), closureOf<CurseArtifact> {
             displayName = releaseName
             relations(closureOf<CurseRelation> {
-                embeddedLibrary("auto-config-updated-api")
                 optionalDependency("modmenu")
                 requiredDependency("fabric-api")
+                requiredDependency("cloth-config")
                 requiredDependency("fabric-language-kotlin")
             })
         })

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,26 +3,26 @@ org.gradle.jvmargs=-Xmx2G
 
 # Fabric Properties
 	# Check these on https://fabricmc.net/versions.html
-	minecraft_version=1.18
-	yarn_mappings=1.18+build.1
-	loader_version=0.12.8
+	minecraft_version=1.18.2
+	yarn_mappings=1.18.2+build.2
+	loader_version=0.13.3
 
 	#Fabric api
-    fabric_version=0.43.1+1.18
-	loom_version=0.10-SNAPSHOT
+	fabric_version=0.48.0+1.18.2
+	loom_version=0.11-SNAPSHOT
 
 	# Mod Properties
-	mod_version = 1.2.2+1.18
+	mod_version = 1.2.3+1.18.2
 	maven_group = me.cael
 	archives_base_name = capes
 
 # Kotlin
-	kotlin_version=1.5.10
-    fabric_kotlin_version=1.6.1+kotlin.1.5.10
+	kotlin_version=1.6.10
+	fabric_kotlin_version=1.7.1+kotlin.1.6.10
 
 # Other APIs
-	autoconfig_version=3.2.2
-	modmenu_version=3.0.0
+	cloth_version=6.2.57
+	modmenu_version=3.1.0
 	
 # Gradle Plugins
 	grgit_version=4.1.0

--- a/src/main/java/me/cael/capes/mixins/MixinElytraFeatureRenderer.java
+++ b/src/main/java/me/cael/capes/mixins/MixinElytraFeatureRenderer.java
@@ -2,7 +2,7 @@ package me.cael.capes.mixins;
 
 import me.cael.capes.CapeConfig;
 import me.cael.capes.handler.PlayerHandler;
-import me.sargunvohra.mcmods.autoconfig1u.AutoConfig;
+import me.shedaniel.autoconfig.AutoConfig;
 import net.minecraft.client.network.AbstractClientPlayerEntity;
 import net.minecraft.client.render.entity.feature.ElytraFeatureRenderer;
 import org.spongepowered.asm.mixin.Mixin;

--- a/src/main/kotlin/me/cael/capes/CapeConfig.kt
+++ b/src/main/kotlin/me/cael/capes/CapeConfig.kt
@@ -1,7 +1,7 @@
 package me.cael.capes
 
-import me.sargunvohra.mcmods.autoconfig1u.ConfigData
-import me.sargunvohra.mcmods.autoconfig1u.annotation.Config
+import me.shedaniel.autoconfig.ConfigData
+import me.shedaniel.autoconfig.annotation.Config
 
 @Config(name = "capes")
 class CapeConfig : ConfigData {

--- a/src/main/kotlin/me/cael/capes/CapeMenu.kt
+++ b/src/main/kotlin/me/cael/capes/CapeMenu.kt
@@ -1,8 +1,8 @@
 package me.cael.capes
 
 import me.cael.capes.mixins.AccessorPlayerListEntry
-import me.sargunvohra.mcmods.autoconfig1u.AutoConfig
-import me.sargunvohra.mcmods.autoconfig1u.ConfigManager
+import me.shedaniel.autoconfig.AutoConfig
+import me.shedaniel.autoconfig.ConfigManager
 import net.minecraft.client.gui.DrawableHelper
 import net.minecraft.client.gui.screen.ConfirmChatLinkScreen
 import net.minecraft.client.gui.screen.Screen

--- a/src/main/kotlin/me/cael/capes/CapeType.kt
+++ b/src/main/kotlin/me/cael/capes/CapeType.kt
@@ -1,7 +1,7 @@
 package me.cael.capes
 
 import com.mojang.authlib.GameProfile
-import me.sargunvohra.mcmods.autoconfig1u.AutoConfig
+import me.shedaniel.autoconfig.AutoConfig
 import net.minecraft.client.gui.screen.ScreenTexts
 import net.minecraft.text.Text
 import net.minecraft.text.TranslatableText

--- a/src/main/kotlin/me/cael/capes/Capes.kt
+++ b/src/main/kotlin/me/cael/capes/Capes.kt
@@ -1,7 +1,7 @@
 package me.cael.capes
 
-import me.sargunvohra.mcmods.autoconfig1u.AutoConfig
-import me.sargunvohra.mcmods.autoconfig1u.serializer.JanksonConfigSerializer
+import me.shedaniel.autoconfig.AutoConfig
+import me.shedaniel.autoconfig.serializer.JanksonConfigSerializer
 import net.fabricmc.api.ClientModInitializer
 
 

--- a/src/main/kotlin/me/cael/capes/handler/PlayerHandler.kt
+++ b/src/main/kotlin/me/cael/capes/handler/PlayerHandler.kt
@@ -8,7 +8,7 @@ import me.cael.capes.CapeConfig
 import me.cael.capes.CapeType
 import me.cael.capes.handler.data.MCMData
 import me.cael.capes.handler.data.WynntilsData
-import me.sargunvohra.mcmods.autoconfig1u.AutoConfig
+import me.shedaniel.autoconfig.AutoConfig
 import net.minecraft.client.MinecraftClient
 import net.minecraft.client.texture.NativeImage
 import net.minecraft.client.texture.NativeImageBackedTexture

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -34,11 +34,11 @@
     "capes.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.12.8",
+    "fabricloader": ">=0.13.3",
     "fabric": "*",
     "fabric-language-kotlin": "*",
     "minecraft": "1.18.x",
-    "autoconfig1u": "*",
+    "cloth-config": "*",
     "java": ">=17"
   }
 }


### PR DESCRIPTION
Updated mod and dependencies for 1.18.2

This addresses issue #48 that I opened, replacing autoconfig1u with cloth-config, which now bundles autoconfig. While it's possible to continue using [autoconfig1u](https://www.curseforge.com/minecraft/mc-mods/auto-config-updated-api), that behavior isn't recommended and likely will cause breakage in the future. Hopefully, this will help future-proof the mod so it continues working, and additionally fixes the error message thrown on startup in 1.18.2. Note, this does have the effect of adding Cloth Config as a dependency, as it's not recommended to compile the mod with it included.