### PR TITLE
Add Cosmetica support

### DIFF
--- a/src/main/kotlin/me/cael/capes/CapeConfig.kt
+++ b/src/main/kotlin/me/cael/capes/CapeConfig.kt
@@ -8,6 +8,7 @@ class CapeConfig : Config {
     var enableLabyMod = false
     var enableWynntils = false
     var enableMinecraftCapesMod = false
+    var enableCosmetica = false
     var enableElytraTexture = true
 
     override fun getName(): String = "capes"

--- a/src/main/kotlin/me/cael/capes/CapeMenu.kt
+++ b/src/main/kotlin/me/cael/capes/CapeMenu.kt
@@ -53,7 +53,12 @@ class CapeMenu(parent: Screen, gameOptions: GameOptions) : GameOptionsScreen(par
             config.save()
             buttonWidget.message = CapeType.WYNNTILS.getToggleText(config.enableWynntils)
         })
-        addDrawableChild(ButtonWidget(width / 2 - 100, height / 6 + 3 * 24, 200, 20, TranslatableText("options.capes.optifineeditor")) { buttonWidget: ButtonWidget ->
+        addDrawableChild(ButtonWidget(width / 2 - 155, height / 6 + 3 * 24, 150, 20, CapeType.COSMETICA.getToggleText(config.enableCosmetica)) { buttonWidget: ButtonWidget ->
+            config.enableCosmetica = !config.enableCosmetica
+            config.save()
+            buttonWidget.message = CapeType.COSMETICA.getToggleText(config.enableCosmetica)
+        })
+        addDrawableChild(ButtonWidget(width / 2 - 155 + 160, height / 6 + 3 * 24, 150, 20, TranslatableText("options.capes.optifineeditor")) { buttonWidget: ButtonWidget ->
             try {
                 val random1Bi = BigInteger(128, Random())
                 val random2Bi = BigInteger(128, Random(System.identityHashCode(Object()).toLong()))

--- a/src/main/kotlin/me/cael/capes/CapeType.kt
+++ b/src/main/kotlin/me/cael/capes/CapeType.kt
@@ -6,13 +6,14 @@ import net.minecraft.text.Text
 import net.minecraft.text.TranslatableText
 
 enum class CapeType(val stylized: String) {
-    MINECRAFT("Minecraft"), OPTIFINE("OptiFine"), LABYMOD("LabyMod"), WYNNTILS("Wynntils"), MINECRAFTCAPES("MinecraftCapes");
+    MINECRAFT("Minecraft"), OPTIFINE("OptiFine"), LABYMOD("LabyMod"), WYNNTILS("Wynntils"), MINECRAFTCAPES("MinecraftCapes"), COSMETICA("Cosmetica");
 
     fun cycle() = when(this) {
         MINECRAFT -> OPTIFINE
         OPTIFINE -> LABYMOD
         LABYMOD -> WYNNTILS
-        WYNNTILS -> MINECRAFTCAPES
+        WYNNTILS -> COSMETICA
+        COSMETICA -> MINECRAFTCAPES
         MINECRAFTCAPES -> MINECRAFT
     }
 
@@ -22,6 +23,7 @@ enum class CapeType(val stylized: String) {
             OPTIFINE -> if(config.enableOptifine) "http://s.optifine.net/capes/${profile.name}.png" else null
             LABYMOD -> if(config.enableLabyMod) "https://dl.labymod.net/capes/${profile.id}" else null
             WYNNTILS -> if(config.enableWynntils) "https://athena.wynntils.com/user/getInfo" else null
+            COSMETICA -> if(config.enableCosmetica) "http://api.cosmetica.cc/get/cloak?username=${profile.name}&uuid=${profile.id}&nothirdparty" else null
             MINECRAFTCAPES -> if(config.enableMinecraftCapesMod) "https://minecraftcapes.net/profile/${profile.id.toString().replace("-", "")}" else null
             MINECRAFT -> null
         }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -4,7 +4,7 @@
   "version": "${version}",
 
   "name": "Capes",
-  "description": "A Fabric mod that lets you use capes from Optifine, LabyMod, and the MinecraftCapes Mod.",
+  "description": "A Fabric mod that lets you use capes from Optifine, LabyMod, Cosmetica, Wynntils, and the MinecraftCapes Mod.",
   "authors": [
     "Cael"
   ],


### PR DESCRIPTION
[Cosmetica](https://cosmetica.cc) is a capes mod and service that aims to be totally Minecraft EULA compliant. This PR adds Cosmetica as a supported platform (and rearranges the settings menu slightly to compensate for the new addition).

Other cape services that could be supported in future include:
- Cloaks+
- Mantle
- Arc
- 5zig
cape APIs for all these are easily accessible.