### PR TITLE
fix: Replace the old MinecraftCapes API endpoints with the new one

### DIFF
--- a/common/src/main/kotlin/me/cael/capes/CapeType.kt
+++ b/common/src/main/kotlin/me/cael/capes/CapeType.kt
@@ -24,7 +24,7 @@ enum class CapeType(val stylized: String) {
             LABYMOD -> if(config.enableLabyMod) "https://dl.labymod.net/capes/${profile.id}" else null
             WYNNTILS -> if(config.enableWynntils) "https://athena.wynntils.com/user/getInfo" else null
             COSMETICA -> if(config.enableCosmetica) "https://api.cosmetica.cc/get/cloak?username=${profile.name}&uuid=${profile.id}&nothirdparty" else null
-            MINECRAFTCAPES -> if(config.enableMinecraftCapesMod) "https://minecraftcapes.net/profile/${profile.id.toString().replace("-", "")}" else null
+            MINECRAFTCAPES -> if(config.enableMinecraftCapesMod) "https://api.minecraftcapes.net/profile/${profile.id.toString().replace("-", "")}" else null
             CLOAKSPLUS -> if(config.enableCloaksPlus) "http://161.35.130.99/capes/${profile.name}.png" else null
             MINECRAFT -> null
         }


### PR DESCRIPTION
![image](https://github.com/CaelTheColher/Capes/assets/57800056/93e25c1b-6871-48c3-9cb1-438524adf72d)
The dev says that they will move to the new endpoints (api subdomain), and the new one already live!