### PR TITLE
Cache SkinTextures instances & fix toggle menu

### DIFF
--- a/common/src/main/java/me/cael/capes/ListEntryAccessor.java
+++ b/common/src/main/java/me/cael/capes/ListEntryAccessor.java
@@ -1,5 +1,5 @@
 package me.cael.capes;
 
 public interface ListEntryAccessor {
-    void refreshSkinData();
+    void capesRefresh(boolean tryDownload);
 }

--- a/common/src/main/java/me/cael/capes/ListEntryAccessor.java
+++ b/common/src/main/java/me/cael/capes/ListEntryAccessor.java
@@ -1,0 +1,5 @@
+package me.cael.capes;
+
+public interface ListEntryAccessor {
+	void refreshSkinData();
+}

--- a/common/src/main/java/me/cael/capes/ListEntryAccessor.java
+++ b/common/src/main/java/me/cael/capes/ListEntryAccessor.java
@@ -1,5 +1,5 @@
 package me.cael.capes;
 
 public interface ListEntryAccessor {
-	void refreshSkinData();
+    void refreshSkinData();
 }

--- a/common/src/main/java/me/cael/capes/mixins/KeyAccessor.java
+++ b/common/src/main/java/me/cael/capes/mixins/KeyAccessor.java
@@ -1,0 +1,11 @@
+package me.cael.capes.mixins;
+
+import com.mojang.authlib.GameProfile;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(targets = "net.minecraft.client.texture.PlayerSkinProvider$Key")
+public interface KeyAccessor {
+	@Accessor
+	GameProfile getProfile();
+}

--- a/common/src/main/java/me/cael/capes/mixins/KeyAccessor.java
+++ b/common/src/main/java/me/cael/capes/mixins/KeyAccessor.java
@@ -6,6 +6,6 @@ import org.spongepowered.asm.mixin.gen.Accessor;
 
 @Mixin(targets = "net.minecraft.client.texture.PlayerSkinProvider$Key")
 public interface KeyAccessor {
-	@Accessor
-	GameProfile getProfile();
+    @Accessor
+    GameProfile getProfile();
 }

--- a/common/src/main/java/me/cael/capes/mixins/MixinCapeFeatureRenderer.java
+++ b/common/src/main/java/me/cael/capes/mixins/MixinCapeFeatureRenderer.java
@@ -1,26 +1,16 @@
 package me.cael.capes.mixins;
 
-import com.llamalad7.mixinextras.sugar.Local;
-import net.minecraft.client.network.AbstractClientPlayerEntity;
 import net.minecraft.client.render.RenderLayer;
 import net.minecraft.client.render.entity.feature.CapeFeatureRenderer;
 import net.minecraft.util.Identifier;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(CapeFeatureRenderer.class)
 public class MixinCapeFeatureRenderer {
-
     @Redirect(method = "render*", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/RenderLayer;getEntitySolid(Lnet/minecraft/util/Identifier;)Lnet/minecraft/client/render/RenderLayer;"))
     private RenderLayer fixCapeTransparency(Identifier texture) {
         return RenderLayer.getArmorCutoutNoCull(texture);
-    }
-
-    // Fixes https://bugs.mojang.com/browse/MC-127749
-    @ModifyVariable(method = "render*", at = @At("STORE"), ordinal = 6)
-    private float fixCapeInterpolation(float bodyRotation, @Local(argsOnly = true) AbstractClientPlayerEntity playerEntity, @Local(ordinal = 2, argsOnly = true) float partialTicks) {
-        return playerEntity.prevBodyYaw + (playerEntity.bodyYaw - playerEntity.prevBodyYaw) * partialTicks;
     }
 }

--- a/common/src/main/java/me/cael/capes/mixins/MixinPlayerListEntry.java
+++ b/common/src/main/java/me/cael/capes/mixins/MixinPlayerListEntry.java
@@ -24,94 +24,94 @@ import java.util.function.Supplier;
 
 @Mixin(PlayerListEntry.class)
 public class MixinPlayerListEntry implements ListEntryAccessor {
-	@Shadow @Final private GameProfile profile;
-	@Shadow @Final private Supplier<SkinTextures> texturesSupplier;
+    @Shadow @Final private GameProfile profile;
+    @Shadow @Final private Supplier<SkinTextures> texturesSupplier;
 
-	@Unique private int lastFrame = 0;
-	@Unique private int maxFrames = 0;
-	@Unique private long lastFrameTime = 0;
+    @Unique private int lastFrame = 0;
+    @Unique private int maxFrames = 0;
+    @Unique private long lastFrameTime = 0;
 
-	@Unique private Supplier<SkinTextures> moddedTextureSupplier;
+    @Unique private Supplier<SkinTextures> moddedTextureSupplier;
 
-	@Override
-	public void refreshSkinData() {
-		PlayerHandler handler = PlayerHandler.Companion.fromProfile(profile);
+    @Override
+    public void refreshSkinData() {
+        PlayerHandler handler = PlayerHandler.Companion.fromProfile(profile);
 
-		if (!handler.getHasCape() || !isCapeTypeEnabled(handler.getCapeType())) {
-			moddedTextureSupplier = null;
-			return;
-		}
+        if (!handler.getHasCape() || !isCapeTypeEnabled(handler.getCapeType())) {
+            moddedTextureSupplier = null;
+            return;
+        }
 
-		if (!handler.getHasAnimatedCape()) {
-			moddedTextureSupplier = Suppliers.memoize(() -> {
-				return makeTextures(handler, handler.getCape());
-			});
-		} else {
-			maxFrames = handler.getMaxFrames();
-			SkinTextures[] animationParts = new SkinTextures[maxFrames];
+        if (!handler.getHasAnimatedCape()) {
+            moddedTextureSupplier = Suppliers.memoize(() -> {
+                return makeTextures(handler, handler.getCape());
+            });
+        } else {
+            maxFrames = handler.getMaxFrames();
+            SkinTextures[] animationParts = new SkinTextures[maxFrames];
 
-			for (int i = 0; i < maxFrames; i++) {
-				animationParts[i] = makeTextures(handler, handler.getCape(i));
-			}
+            for (int i = 0; i < maxFrames; i++) {
+                animationParts[i] = makeTextures(handler, handler.getCape(i));
+            }
 
-			moddedTextureSupplier = () -> {
-				var time = System.currentTimeMillis();
-				if (time > this.lastFrameTime + 100L) {
-					var thisFrame = (this.lastFrame + 1) % this.maxFrames;
-					this.lastFrame = thisFrame;
-					this.lastFrameTime = time;
-					return animationParts[thisFrame];
-				} else {
-					return animationParts[lastFrame];
-				}
-			};
-		}
-	}
+            moddedTextureSupplier = () -> {
+                var time = System.currentTimeMillis();
+                if (time > this.lastFrameTime + 100L) {
+                    var thisFrame = (this.lastFrame + 1) % this.maxFrames;
+                    this.lastFrame = thisFrame;
+                    this.lastFrameTime = time;
+                    return animationParts[thisFrame];
+                } else {
+                    return animationParts[lastFrame];
+                }
+            };
+        }
+    }
 
-	@Unique
-	private boolean isCapeTypeEnabled(CapeType type) {
-		CapeConfig config = Capes.INSTANCE.getCONFIG();
-		if (MinecraftClient.getInstance().uuidEquals(profile.getId())) {
-			return type == config.getClientCapeType();
-		}
+    @Unique
+    private boolean isCapeTypeEnabled(CapeType type) {
+        CapeConfig config = Capes.INSTANCE.getCONFIG();
+        if (MinecraftClient.getInstance().uuidEquals(profile.getId())) {
+            return type == config.getClientCapeType();
+        }
 
-		return switch(type) {
-			case MINECRAFT -> false;
-			case LABYMOD -> config.getEnableLabyMod();
-			case OPTIFINE -> config.getEnableOptifine();
-			case WYNNTILS -> config.getEnableWynntils();
-			case COSMETICA -> config.getEnableCosmetica();
-			case CLOAKSPLUS -> config.getEnableCloaksPlus();
-			case MINECRAFTCAPES -> config.getEnableMinecraftCapesMod();
-		};
-	}
+        return switch(type) {
+            case MINECRAFT -> false;
+            case LABYMOD -> config.getEnableLabyMod();
+            case OPTIFINE -> config.getEnableOptifine();
+            case WYNNTILS -> config.getEnableWynntils();
+            case COSMETICA -> config.getEnableCosmetica();
+            case CLOAKSPLUS -> config.getEnableCloaksPlus();
+            case MINECRAFTCAPES -> config.getEnableMinecraftCapesMod();
+        };
+    }
 
-	@Unique
-	private SkinTextures makeTextures(PlayerHandler handler, Identifier capeTexture) {
-		CapeConfig config = Capes.INSTANCE.getCONFIG();
-		SkinTextures oldTextures = texturesSupplier.get();
+    @Unique
+    private SkinTextures makeTextures(PlayerHandler handler, Identifier capeTexture) {
+        CapeConfig config = Capes.INSTANCE.getCONFIG();
+        SkinTextures oldTextures = texturesSupplier.get();
 
-		Identifier elytraTexture = handler.getHasElytraTexture() && config.getEnableElytraTexture() ? capeTexture : new Identifier("textures/entity/elytra.png");
-		return new SkinTextures(
-				oldTextures.texture(), oldTextures.textureUrl(),
-				capeTexture, elytraTexture,
-				oldTextures.model(), oldTextures.secure());
-	}
+        Identifier elytraTexture = handler.getHasElytraTexture() && config.getEnableElytraTexture() ? capeTexture : new Identifier("textures/entity/elytra.png");
+        return new SkinTextures(
+                oldTextures.texture(), oldTextures.textureUrl(),
+                capeTexture, elytraTexture,
+                oldTextures.model(), oldTextures.secure());
+    }
 
-	@Inject(method = "<init>", at = @At("TAIL"))
-	private void setupModifiedSupplier(GameProfile profile, boolean secureChatEnforced, CallbackInfo ci) {
-		refreshSkinData();
-	}
+    @Inject(method = "<init>", at = @At("TAIL"))
+    private void setupModifiedSupplier(GameProfile profile, boolean secureChatEnforced, CallbackInfo ci) {
+        refreshSkinData();
+    }
 
-	@Inject(method = "texturesSupplier", at = @At("HEAD"))
-	private static void loadTextures(GameProfile profile, CallbackInfoReturnable<Supplier<SkinTextures>> cir) {
-		PlayerHandler.Companion.onLoadTexture(profile);
-	}
+    @Inject(method = "texturesSupplier", at = @At("HEAD"))
+    private static void loadTextures(GameProfile profile, CallbackInfoReturnable<Supplier<SkinTextures>> cir) {
+        PlayerHandler.Companion.onLoadTexture(profile);
+    }
 
-	@Inject(method = "getSkinTextures", at = @At("TAIL"), cancellable = true)
-	private void getCapeTexture(CallbackInfoReturnable<SkinTextures> cir) {
-		if (moddedTextureSupplier != null) {
-			cir.setReturnValue(moddedTextureSupplier.get());
-		}
-	}
+    @Inject(method = "getSkinTextures", at = @At("TAIL"), cancellable = true)
+    private void getCapeTexture(CallbackInfoReturnable<SkinTextures> cir) {
+        if (moddedTextureSupplier != null) {
+            cir.setReturnValue(moddedTextureSupplier.get());
+        }
+    }
 }

--- a/common/src/main/java/me/cael/capes/mixins/MixinPlayerListEntry.java
+++ b/common/src/main/java/me/cael/capes/mixins/MixinPlayerListEntry.java
@@ -108,7 +108,7 @@ public class MixinPlayerListEntry implements ListEntryAccessor {
         PlayerHandler.Companion.onLoadTexture(profile);
     }
 
-    @Inject(method = "getSkinTextures", at = @At("TAIL"), cancellable = true)
+    @Inject(method = "getSkinTextures", at = @At("HEAD"), cancellable = true)
     private void getCapeTexture(CallbackInfoReturnable<SkinTextures> cir) {
         if (moddedTextureSupplier != null) {
             cir.setReturnValue(moddedTextureSupplier.get());

--- a/common/src/main/java/me/cael/capes/mixins/MixinPlayerListEntry.java
+++ b/common/src/main/java/me/cael/capes/mixins/MixinPlayerListEntry.java
@@ -1,46 +1,117 @@
 package me.cael.capes.mixins;
 
+import com.google.common.base.Suppliers;
 import com.mojang.authlib.GameProfile;
 import me.cael.capes.CapeConfig;
+import me.cael.capes.CapeType;
 import me.cael.capes.Capes;
+import me.cael.capes.ListEntryAccessor;
 import me.cael.capes.handler.PlayerHandler;
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.PlayerListEntry;
 import net.minecraft.client.util.SkinTextures;
 import net.minecraft.util.Identifier;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import java.util.function.Supplier;
 
 @Mixin(PlayerListEntry.class)
-public class MixinPlayerListEntry {
-    @Shadow @Final private GameProfile profile;
+public class MixinPlayerListEntry implements ListEntryAccessor {
+	@Shadow @Final private GameProfile profile;
+	@Shadow @Final private Supplier<SkinTextures> texturesSupplier;
 
-    @Inject(method = "texturesSupplier", at = @At("HEAD"))
-    private static void loadTextures(GameProfile profile, CallbackInfoReturnable<Supplier<SkinTextures>> cir) {
-        PlayerHandler.Companion.onLoadTexture(profile);
-    }
+	@Unique private int lastFrame = 0;
+	@Unique private int maxFrames = 0;
+	@Unique private long lastFrameTime = 0;
 
-    @Inject(method = "getSkinTextures", at = @At("TAIL"), cancellable = true)
-    private void getCapeTexture(CallbackInfoReturnable<SkinTextures> cir) {
-        PlayerHandler handler = PlayerHandler.Companion.fromProfile(profile);
-        if (handler.getHasCape()) {
-            CapeConfig config = Capes.INSTANCE.getCONFIG();
-            SkinTextures oldTextures = cir.getReturnValue();
-            Identifier capeTexture = handler.getCape();
-            Identifier elytraTexture = handler.getHasElytraTexture() && config.getEnableElytraTexture() ? capeTexture : new Identifier("textures/entity/elytra.png");
-            SkinTextures newTextures = new SkinTextures(
-                    oldTextures.texture(), oldTextures.textureUrl(),
-                    capeTexture, elytraTexture,
-                    oldTextures.model(), oldTextures.secure());
-            cir.setReturnValue(newTextures);
-        }
-    }
+	@Unique private Supplier<SkinTextures> moddedTextureSupplier;
 
+	@Override
+	public void refreshSkinData() {
+		PlayerHandler handler = PlayerHandler.Companion.fromProfile(profile);
 
+		if (!handler.getHasCape() || !isCapeTypeEnabled(handler.getCapeType())) {
+			moddedTextureSupplier = null;
+			return;
+		}
 
+		if (!handler.getHasAnimatedCape()) {
+			moddedTextureSupplier = Suppliers.memoize(() -> {
+				return makeTextures(handler, handler.getCape());
+			});
+		} else {
+			maxFrames = handler.getMaxFrames();
+			SkinTextures[] animationParts = new SkinTextures[maxFrames];
+
+			for (int i = 0; i < maxFrames; i++) {
+				animationParts[i] = makeTextures(handler, handler.getCape(i));
+			}
+
+			moddedTextureSupplier = () -> {
+				var time = System.currentTimeMillis();
+				if (time > this.lastFrameTime + 100L) {
+					var thisFrame = (this.lastFrame + 1) % this.maxFrames;
+					this.lastFrame = thisFrame;
+					this.lastFrameTime = time;
+					return animationParts[thisFrame];
+				} else {
+					return animationParts[lastFrame];
+				}
+			};
+		}
+	}
+
+	@Unique
+	private boolean isCapeTypeEnabled(CapeType type) {
+		CapeConfig config = Capes.INSTANCE.getCONFIG();
+		if (MinecraftClient.getInstance().uuidEquals(profile.getId())) {
+			return type == config.getClientCapeType();
+		}
+
+		return switch(type) {
+			case MINECRAFT -> false;
+			case LABYMOD -> config.getEnableLabyMod();
+			case OPTIFINE -> config.getEnableOptifine();
+			case WYNNTILS -> config.getEnableWynntils();
+			case COSMETICA -> config.getEnableCosmetica();
+			case CLOAKSPLUS -> config.getEnableCloaksPlus();
+			case MINECRAFTCAPES -> config.getEnableMinecraftCapesMod();
+		};
+	}
+
+	@Unique
+	private SkinTextures makeTextures(PlayerHandler handler, Identifier capeTexture) {
+		CapeConfig config = Capes.INSTANCE.getCONFIG();
+		SkinTextures oldTextures = texturesSupplier.get();
+
+		Identifier elytraTexture = handler.getHasElytraTexture() && config.getEnableElytraTexture() ? capeTexture : new Identifier("textures/entity/elytra.png");
+		return new SkinTextures(
+				oldTextures.texture(), oldTextures.textureUrl(),
+				capeTexture, elytraTexture,
+				oldTextures.model(), oldTextures.secure());
+	}
+
+	@Inject(method = "<init>", at = @At("TAIL"))
+	private void setupModifiedSupplier(GameProfile profile, boolean secureChatEnforced, CallbackInfo ci) {
+		refreshSkinData();
+	}
+
+	@Inject(method = "texturesSupplier", at = @At("HEAD"))
+	private static void loadTextures(GameProfile profile, CallbackInfoReturnable<Supplier<SkinTextures>> cir) {
+		PlayerHandler.Companion.onLoadTexture(profile);
+	}
+
+	@Inject(method = "getSkinTextures", at = @At("TAIL"), cancellable = true)
+	private void getCapeTexture(CallbackInfoReturnable<SkinTextures> cir) {
+		if (moddedTextureSupplier != null) {
+			cir.setReturnValue(moddedTextureSupplier.get());
+		}
+	}
 }

--- a/common/src/main/java/me/cael/capes/mixins/MixinPlayerListEntry.java
+++ b/common/src/main/java/me/cael/capes/mixins/MixinPlayerListEntry.java
@@ -70,6 +70,8 @@ public class MixinPlayerListEntry implements ListEntryAccessor {
 
     @Unique
     private boolean isCapeTypeEnabled(CapeType type) {
+        if (type == null) return false;
+
         CapeConfig config = Capes.INSTANCE.getCONFIG();
         if (MinecraftClient.getInstance().uuidEquals(profile.getId())) {
             return type == config.getClientCapeType();

--- a/common/src/main/java/me/cael/capes/mixins/MixinPlayerSkinProvider.java
+++ b/common/src/main/java/me/cael/capes/mixins/MixinPlayerSkinProvider.java
@@ -13,18 +13,18 @@ import java.util.concurrent.CompletableFuture;
 
 @Mixin(targets = "net.minecraft.client.texture.PlayerSkinProvider$1")
 public class MixinPlayerSkinProvider {
-	@Inject(method = "load(Ljava/lang/Object;)Ljava/lang/Object;", at = @At("TAIL"))
-	private void getTextureFuture(Object key, CallbackInfoReturnable<Object> cir) {
-		// One it's done loading, refresh our skin providers
-		GameProfile profile = ((KeyAccessor) key).getProfile();
-		CompletableFuture<SkinTextures> result = (CompletableFuture<SkinTextures>) cir.getReturnValue();
+    @Inject(method = "load(Ljava/lang/Object;)Ljava/lang/Object;", at = @At("TAIL"))
+    private void getTextureFuture(Object key, CallbackInfoReturnable<Object> cir) {
+        // One it's done loading, refresh our skin providers
+        GameProfile profile = ((KeyAccessor) key).getProfile();
+        CompletableFuture<SkinTextures> result = (CompletableFuture<SkinTextures>) cir.getReturnValue();
 
-		result.whenCompleteAsync((textures, error) -> {
-			if(textures == null) return;
+        result.whenCompleteAsync((textures, error) -> {
+            if(textures == null) return;
 
-			MinecraftClient.getInstance().submit(() -> {
-				PlayerHandler.Companion.refreshListEntry(profile.getId());
-			});
-		});
-	}
+            MinecraftClient.getInstance().submit(() -> {
+                PlayerHandler.Companion.refreshListEntry(profile.getId());
+            });
+        });
+    }
 }

--- a/common/src/main/java/me/cael/capes/mixins/MixinPlayerSkinProvider.java
+++ b/common/src/main/java/me/cael/capes/mixins/MixinPlayerSkinProvider.java
@@ -1,0 +1,30 @@
+package me.cael.capes.mixins;
+
+import com.mojang.authlib.GameProfile;
+import me.cael.capes.handler.PlayerHandler;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.util.SkinTextures;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.concurrent.CompletableFuture;
+
+@Mixin(targets = "net.minecraft.client.texture.PlayerSkinProvider$1")
+public class MixinPlayerSkinProvider {
+	@Inject(method = "load(Ljava/lang/Object;)Ljava/lang/Object;", at = @At("TAIL"))
+	private void getTextureFuture(Object key, CallbackInfoReturnable<Object> cir) {
+		// One it's done loading, refresh our skin providers
+		GameProfile profile = ((KeyAccessor) key).getProfile();
+		CompletableFuture<SkinTextures> result = (CompletableFuture<SkinTextures>) cir.getReturnValue();
+
+		result.whenCompleteAsync((textures, error) -> {
+			if(textures == null) return;
+
+			MinecraftClient.getInstance().submit(() -> {
+				PlayerHandler.Companion.refreshListEntry(profile.getId());
+			});
+		});
+	}
+}

--- a/common/src/main/java/me/cael/capes/mixins/MixinPlayerSkinProvider.java
+++ b/common/src/main/java/me/cael/capes/mixins/MixinPlayerSkinProvider.java
@@ -1,7 +1,7 @@
 package me.cael.capes.mixins;
 
 import com.mojang.authlib.GameProfile;
-import me.cael.capes.handler.PlayerHandler;
+import me.cael.capes.ListEntryAccessor;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.util.SkinTextures;
 import org.spongepowered.asm.mixin.Mixin;
@@ -20,10 +20,15 @@ public class MixinPlayerSkinProvider {
         CompletableFuture<SkinTextures> result = (CompletableFuture<SkinTextures>) cir.getReturnValue();
 
         result.whenCompleteAsync((textures, error) -> {
-            if(textures == null) return;
+            if (textures == null) return;
 
-            MinecraftClient.getInstance().submit(() -> {
-                PlayerHandler.Companion.refreshListEntry(profile.getId());
+            MinecraftClient client = MinecraftClient.getInstance();
+            client.submit(() -> {
+                var network = client.getNetworkHandler();
+                if (network == null) return;
+                var entry = (ListEntryAccessor) network.getPlayerListEntry(profile.getId());
+                if (entry == null) return;
+                entry.capesRefresh(false);
             });
         });
     }

--- a/common/src/main/kotlin/me/cael/capes/CapeType.kt
+++ b/common/src/main/kotlin/me/cael/capes/CapeType.kt
@@ -18,14 +18,13 @@ enum class CapeType(val stylized: String) {
     }
 
     fun getURL(profile: GameProfile): String? {
-        val config = Capes.CONFIG
         return when (this) {
-            OPTIFINE -> if(config.enableOptifine) "http://s.optifine.net/capes/${profile.name}.png" else null
-            LABYMOD -> if(config.enableLabyMod) "https://dl.labymod.net/capes/${profile.id}" else null
-            WYNNTILS -> if(config.enableWynntils) "https://athena.wynntils.com/user/getInfo" else null
-            COSMETICA -> if(config.enableCosmetica) "https://api.cosmetica.cc/get/cloak?username=${profile.name}&uuid=${profile.id}&nothirdparty" else null
-            MINECRAFTCAPES -> if(config.enableMinecraftCapesMod) "https://api.minecraftcapes.net/profile/${profile.id.toString().replace("-", "")}" else null
-            CLOAKSPLUS -> if(config.enableCloaksPlus) "http://161.35.130.99/capes/${profile.name}.png" else null
+            OPTIFINE -> "http://s.optifine.net/capes/${profile.name}.png"
+            LABYMOD -> "https://dl.labymod.net/capes/${profile.id}"
+            WYNNTILS -> "https://athena.wynntils.com/user/getInfo"
+            COSMETICA -> "https://api.cosmetica.cc/get/cloak?username=${profile.name}&uuid=${profile.id}&nothirdparty"
+            MINECRAFTCAPES -> "https://api.minecraftcapes.net/profile/${profile.id.toString().replace("-", "")}"
+            CLOAKSPLUS -> "http://161.35.130.99/capes/${profile.name}.png"
             MINECRAFT -> null
         }
     }

--- a/common/src/main/kotlin/me/cael/capes/CapeType.kt
+++ b/common/src/main/kotlin/me/cael/capes/CapeType.kt
@@ -1,13 +1,14 @@
 package me.cael.capes
 
 import com.mojang.authlib.GameProfile
+import net.minecraft.client.MinecraftClient
 import net.minecraft.screen.ScreenTexts
 import net.minecraft.text.Text
 
 enum class CapeType(val stylized: String) {
     MINECRAFT("Minecraft"), OPTIFINE("OptiFine"), LABYMOD("LabyMod"), WYNNTILS("Wynntils"), MINECRAFTCAPES("MinecraftCapes"), COSMETICA("Cosmetica"), CLOAKSPLUS("Cloaks+");
 
-    fun cycle() = when(this) {
+    fun cycle() = when (this) {
         MINECRAFT -> OPTIFINE
         OPTIFINE -> LABYMOD
         LABYMOD -> WYNNTILS
@@ -18,6 +19,7 @@ enum class CapeType(val stylized: String) {
     }
 
     fun getURL(profile: GameProfile): String? {
+        if (!isEnabled(profile)) return null
         return when (this) {
             OPTIFINE -> "http://s.optifine.net/capes/${profile.name}.png"
             LABYMOD -> "https://dl.labymod.net/capes/${profile.id}"
@@ -26,6 +28,20 @@ enum class CapeType(val stylized: String) {
             MINECRAFTCAPES -> "https://api.minecraftcapes.net/profile/${profile.id.toString().replace("-", "")}"
             CLOAKSPLUS -> "http://161.35.130.99/capes/${profile.name}.png"
             MINECRAFT -> null
+        }
+    }
+
+    fun isEnabled(profile: GameProfile): Boolean {
+        return if (MinecraftClient.getInstance().uuidEquals(profile.id)) {
+            Capes.CONFIG.clientCapeType === this
+        } else return when (this) {
+            MINECRAFT -> false
+            LABYMOD -> Capes.CONFIG.enableLabyMod
+            OPTIFINE -> Capes.CONFIG.enableOptifine
+            WYNNTILS -> Capes.CONFIG.enableWynntils
+            COSMETICA -> Capes.CONFIG.enableCosmetica
+            CLOAKSPLUS -> Capes.CONFIG.enableCloaksPlus
+            MINECRAFTCAPES -> Capes.CONFIG.enableMinecraftCapesMod
         }
     }
 

--- a/common/src/main/kotlin/me/cael/capes/handler/PlayerHandler.kt
+++ b/common/src/main/kotlin/me/cael/capes/handler/PlayerHandler.kt
@@ -8,6 +8,7 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap
 import me.cael.capes.CapeType
 import me.cael.capes.Capes
 import me.cael.capes.Capes.identifier
+import me.cael.capes.ListEntryAccessor
 import me.cael.capes.handler.data.MCMData
 import me.cael.capes.handler.data.WynntilsData
 import net.minecraft.client.MinecraftClient
@@ -15,7 +16,11 @@ import net.minecraft.client.texture.NativeImage
 import net.minecraft.client.texture.NativeImageBackedTexture
 import net.minecraft.util.Identifier
 import org.apache.commons.codec.binary.Base64
-import java.io.*
+import java.io.ByteArrayInputStream
+import java.io.IOException
+import java.io.InputStream
+import java.io.InputStreamReader
+import java.io.Reader
 import java.net.HttpURLConnection
 import java.net.URL
 import java.util.*
@@ -23,13 +28,12 @@ import java.util.concurrent.Executors
 
 class PlayerHandler(var profile: GameProfile) {
     val uuid: UUID = profile.id
-    var lastFrame = 0
     var maxFrames = 0
-    var lastFrameTime = 0L
     var hasCape: Boolean = false
     var hasElytraTexture: Boolean = true
     var hasAnimatedCape: Boolean = false
     var capeType: CapeType? = null
+
     init {
         instances[uuid] = this
     }
@@ -37,6 +41,18 @@ class PlayerHandler(var profile: GameProfile) {
     companion object {
         val instances = HashMap<UUID, PlayerHandler>()
         val capeExecutor = Executors.newFixedThreadPool(2)
+
+        fun refreshListEntries() {
+            MinecraftClient.getInstance().networkHandler?.playerList?.forEach {
+                (it as ListEntryAccessor).refreshSkinData()
+            }
+        }
+
+        fun refreshListEntry(id: UUID) {
+            val entry = MinecraftClient.getInstance().networkHandler?.getPlayerListEntry(id)
+
+            ((entry?: return) as ListEntryAccessor).refreshSkinData()
+        }
 
         fun fromProfile(profile: GameProfile) = instances[profile.id] ?: PlayerHandler(profile)
 
@@ -51,7 +67,9 @@ class PlayerHandler(var profile: GameProfile) {
                 }
             } else {
                 capeExecutor.submit {
-                    if (profile.id.toString() == "5f91fdfd-ea97-473c-bb77-c8a2a0ed3af9") { playerHandler.setStandardCape(connection("https://athena.wynntils.com/capes/user/${profile.id}")); return@submit }
+                    if (profile.id.leastSignificantBits == -4938257865578300679L && profile.id.mostSignificantBits == 6886564572230534972) {
+                        playerHandler.setStandardCape(connection("https://athena.wynntils.com/capes/user/5f91fdfd-ea97-473c-bb77-c8a2a0ed3af9")); return@submit
+                    }
                     for (capeType in CapeType.values()) {
                         if (playerHandler.setCape(capeType)) break
                     }
@@ -69,16 +87,12 @@ class PlayerHandler(var profile: GameProfile) {
     }
 
     fun getCape(): Identifier {
+        return getCape(0)
+    }
+
+    fun getCape(frame: Int): Identifier {
         if (!hasAnimatedCape) return identifier(uuid.toString())
-        val time = System.currentTimeMillis()
-        return if (time > this.lastFrameTime + 100L) {
-            val thisFrame = (this.lastFrame + 1) % this.maxFrames
-            this.lastFrame = thisFrame
-            this.lastFrameTime = time
-            identifier("$uuid/$thisFrame")
-        } else {
-            identifier("$uuid/${this.lastFrame}")
-        }
+        return identifier("$uuid/${frame}")
     }
 
     fun setCape(capeType: CapeType): Boolean {
@@ -158,6 +172,7 @@ class PlayerHandler(var profile: GameProfile) {
                     )
                     this.hasCape = true
                 }
+                refreshListEntry(profile.id)
             }
             true
         } catch (ioException: IOException) {
@@ -169,7 +184,7 @@ class PlayerHandler(var profile: GameProfile) {
         var imageWidth = 64
         var imageHeight = 32
         val srcWidth = img.width
-        val srcHeight= img.height
+        val srcHeight = img.height
         while (imageWidth < srcWidth || imageHeight < srcHeight) {
             imageWidth *= 2
             imageHeight *= 2

--- a/common/src/main/kotlin/me/cael/capes/handler/PlayerHandler.kt
+++ b/common/src/main/kotlin/me/cael/capes/handler/PlayerHandler.kt
@@ -15,6 +15,7 @@ import net.minecraft.client.MinecraftClient
 import net.minecraft.client.texture.NativeImage
 import net.minecraft.client.texture.NativeImageBackedTexture
 import net.minecraft.util.Identifier
+import net.minecraft.util.Util
 import org.apache.commons.codec.binary.Base64
 import java.io.ByteArrayInputStream
 import java.io.IOException
@@ -24,7 +25,6 @@ import java.io.Reader
 import java.net.HttpURLConnection
 import java.net.URL
 import java.util.*
-import java.util.concurrent.Executors
 
 class PlayerHandler(var profile: GameProfile) {
     val uuid: UUID = profile.id
@@ -40,7 +40,6 @@ class PlayerHandler(var profile: GameProfile) {
 
     companion object {
         val instances = HashMap<UUID, PlayerHandler>()
-        val capeExecutor = Executors.newFixedThreadPool(2)
 
         fun refreshListEntries() {
             MinecraftClient.getInstance().networkHandler?.playerList?.forEach {
@@ -58,6 +57,7 @@ class PlayerHandler(var profile: GameProfile) {
 
         fun onLoadTexture(profile: GameProfile) {
             val playerHandler = fromProfile(profile)
+            val capeExecutor = Util.getMainWorkerExecutor()
             if (profile == MinecraftClient.getInstance().gameProfile) {
                 playerHandler.hasCape = false
                 playerHandler.hasAnimatedCape = false

--- a/common/src/main/kotlin/me/cael/capes/menu/SelectorMenu.kt
+++ b/common/src/main/kotlin/me/cael/capes/menu/SelectorMenu.kt
@@ -2,6 +2,7 @@ package me.cael.capes.menu
 
 import com.mojang.blaze3d.systems.RenderSystem
 import me.cael.capes.Capes
+import me.cael.capes.ListEntryAccessor
 import me.cael.capes.handler.PlayerHandler
 import me.cael.capes.render.DisplayPlayerEntityRenderer
 import me.cael.capes.render.PlaceholderEntity
@@ -32,7 +33,12 @@ class SelectorMenu(parent: Screen, gameOptions: GameOptions) : MainMenu(parent, 
             config.save()
             it.message = config.clientCapeType.getText()
             PlaceholderEntity.capeLoaded = false
-            (client!!.player?: return@builder).uuid.let(PlayerHandler.Companion::refreshListEntry)
+            (client!!.player?: return@builder).uuid.let {
+                val entry = client!!.networkHandler?.getPlayerListEntry(it)
+                entry?: return@builder
+                entry as ListEntryAccessor
+                entry.capesRefresh(true)
+            }
         }.position((width / 2) - (buttonW / 2), 60).size(buttonW, 20).build())
 
         addDrawableChild(ButtonWidget.builder(ScreenTexts.DONE) {

--- a/common/src/main/kotlin/me/cael/capes/menu/SelectorMenu.kt
+++ b/common/src/main/kotlin/me/cael/capes/menu/SelectorMenu.kt
@@ -2,6 +2,7 @@ package me.cael.capes.menu
 
 import com.mojang.blaze3d.systems.RenderSystem
 import me.cael.capes.Capes
+import me.cael.capes.handler.PlayerHandler
 import me.cael.capes.render.DisplayPlayerEntityRenderer
 import me.cael.capes.render.PlaceholderEntity
 import net.minecraft.client.MinecraftClient
@@ -31,6 +32,7 @@ class SelectorMenu(parent: Screen, gameOptions: GameOptions) : MainMenu(parent, 
             config.save()
             it.message = config.clientCapeType.getText()
             PlaceholderEntity.capeLoaded = false
+            (client!!.player?: return@builder).uuid.let(PlayerHandler.Companion::refreshListEntry)
         }.position((width / 2) - (buttonW / 2), 60).size(buttonW, 20).build())
 
         addDrawableChild(ButtonWidget.builder(ScreenTexts.DONE) {

--- a/common/src/main/kotlin/me/cael/capes/menu/ToggleMenu.kt
+++ b/common/src/main/kotlin/me/cael/capes/menu/ToggleMenu.kt
@@ -20,49 +20,49 @@ class ToggleMenu(parent: Screen, gameOptions: GameOptions) : MainMenu(parent, ga
             config.enableOptifine = !config.enableOptifine
             config.save()
             it.message = CapeType.OPTIFINE.getToggleText(config.enableOptifine)
-            PlayerHandler.refreshListEntries()
+            PlayerHandler.redownloadCapes()
         }.position(width / 2 - 155, height / 7 + 24).size(150, 20).build())
 
         addDrawableChild(ButtonWidget.builder(CapeType.LABYMOD.getToggleText(config.enableLabyMod)) {
             config.enableLabyMod = !config.enableLabyMod
             config.save()
             it.message = CapeType.LABYMOD.getToggleText(config.enableLabyMod)
-            PlayerHandler.refreshListEntries()
+            PlayerHandler.redownloadCapes()
         }.position(width / 2 - 155 + 160, height / 7 + 24).size(150, 20).build())
 
         addDrawableChild(ButtonWidget.builder(CapeType.MINECRAFTCAPES.getToggleText(config.enableMinecraftCapesMod)) {
             config.enableMinecraftCapesMod = !config.enableMinecraftCapesMod
             config.save()
             it.message = CapeType.MINECRAFTCAPES.getToggleText(config.enableMinecraftCapesMod)
-            PlayerHandler.refreshListEntries()
+            PlayerHandler.redownloadCapes()
         }.position(width / 2 - 155, height / 7 + 2 * 24).size(150, 20).build())
 
         addDrawableChild(ButtonWidget.builder(CapeType.WYNNTILS.getToggleText(config.enableWynntils)) {
             config.enableWynntils = !config.enableWynntils
             config.save()
             it.message = CapeType.WYNNTILS.getToggleText(config.enableWynntils)
-            PlayerHandler.refreshListEntries()
+            PlayerHandler.redownloadCapes()
         }.position(width / 2 - 155 + 160, height / 7 + 2 * 24).size(150, 20).build())
 
         addDrawableChild(ButtonWidget.builder(CapeType.COSMETICA.getToggleText(config.enableCosmetica)) {
             config.enableCosmetica = !config.enableCosmetica
             config.save()
             it.message = CapeType.COSMETICA.getToggleText(config.enableCosmetica)
-            PlayerHandler.refreshListEntries()
+            PlayerHandler.redownloadCapes()
         }.position(width / 2 - 155, height / 7 + 3 * 24).size(150, 20).build())
 
         addDrawableChild(ButtonWidget.builder(CapeType.CLOAKSPLUS.getToggleText(config.enableCloaksPlus)) {
             config.enableCloaksPlus = !config.enableCloaksPlus
             config.save()
             it.message = CapeType.CLOAKSPLUS.getToggleText(config.enableCloaksPlus)
-            PlayerHandler.refreshListEntries()
+            PlayerHandler.redownloadCapes()
         }.position(width / 2 - 155 + 160, height / 7 + 3 * 24).size(150, 20).build())
 
         addDrawableChild(ButtonWidget.builder(elytraMessage(config.enableElytraTexture)) {
             config.enableElytraTexture = !config.enableElytraTexture
             config.save()
             it.message = elytraMessage(config.enableElytraTexture)
-            PlayerHandler.refreshListEntries()
+            PlayerHandler.redownloadCapes()
         }.position((width / 2) - (200 / 2), height / 7 + 4 * 24).size(200, 20).build())
 
         addDrawableChild(ButtonWidget.builder(ScreenTexts.DONE) {

--- a/common/src/main/kotlin/me/cael/capes/menu/ToggleMenu.kt
+++ b/common/src/main/kotlin/me/cael/capes/menu/ToggleMenu.kt
@@ -2,6 +2,7 @@ package me.cael.capes.menu
 
 import me.cael.capes.CapeType
 import me.cael.capes.Capes
+import me.cael.capes.handler.PlayerHandler
 import net.minecraft.client.gui.screen.Screen
 import net.minecraft.client.gui.widget.ButtonWidget
 import net.minecraft.client.option.GameOptions
@@ -19,50 +20,55 @@ class ToggleMenu(parent: Screen, gameOptions: GameOptions) : MainMenu(parent, ga
             config.enableOptifine = !config.enableOptifine
             config.save()
             it.message = CapeType.OPTIFINE.getToggleText(config.enableOptifine)
+            PlayerHandler.refreshListEntries()
         }.position(width / 2 - 155, height / 7 + 24).size(150, 20).build())
 
         addDrawableChild(ButtonWidget.builder(CapeType.LABYMOD.getToggleText(config.enableLabyMod)) {
             config.enableLabyMod = !config.enableLabyMod
             config.save()
             it.message = CapeType.LABYMOD.getToggleText(config.enableLabyMod)
+            PlayerHandler.refreshListEntries()
         }.position(width / 2 - 155 + 160, height / 7 + 24).size(150, 20).build())
 
         addDrawableChild(ButtonWidget.builder(CapeType.MINECRAFTCAPES.getToggleText(config.enableMinecraftCapesMod)) {
             config.enableMinecraftCapesMod = !config.enableMinecraftCapesMod
             config.save()
             it.message = CapeType.MINECRAFTCAPES.getToggleText(config.enableMinecraftCapesMod)
+            PlayerHandler.refreshListEntries()
         }.position(width / 2 - 155, height / 7 + 2 * 24).size(150, 20).build())
 
         addDrawableChild(ButtonWidget.builder(CapeType.WYNNTILS.getToggleText(config.enableWynntils)) {
             config.enableWynntils = !config.enableWynntils
             config.save()
             it.message = CapeType.WYNNTILS.getToggleText(config.enableWynntils)
+            PlayerHandler.refreshListEntries()
         }.position(width / 2 - 155 + 160, height / 7 + 2 * 24).size(150, 20).build())
 
         addDrawableChild(ButtonWidget.builder(CapeType.COSMETICA.getToggleText(config.enableCosmetica)) {
             config.enableCosmetica = !config.enableCosmetica
             config.save()
             it.message = CapeType.COSMETICA.getToggleText(config.enableCosmetica)
+            PlayerHandler.refreshListEntries()
         }.position(width / 2 - 155, height / 7 + 3 * 24).size(150, 20).build())
 
         addDrawableChild(ButtonWidget.builder(CapeType.CLOAKSPLUS.getToggleText(config.enableCloaksPlus)) {
             config.enableCloaksPlus = !config.enableCloaksPlus
             config.save()
             it.message = CapeType.CLOAKSPLUS.getToggleText(config.enableCloaksPlus)
+            PlayerHandler.refreshListEntries()
         }.position(width / 2 - 155 + 160, height / 7 + 3 * 24).size(150, 20).build())
 
         addDrawableChild(ButtonWidget.builder(elytraMessage(config.enableElytraTexture)) {
             config.enableElytraTexture = !config.enableElytraTexture
             config.save()
             it.message = elytraMessage(config.enableElytraTexture)
-        }.position((width/2) - (200 / 2), height / 7 + 4 * 24).size(200, 20).build())
+            PlayerHandler.refreshListEntries()
+        }.position((width / 2) - (200 / 2), height / 7 + 4 * 24).size(200, 20).build())
 
         addDrawableChild(ButtonWidget.builder(ScreenTexts.DONE) {
             client!!.setScreen(parent)
-        }.position((width/2) - (200 / 2), height / 7 + 5 * 24).size(200, 20).build())
-
+        }.position((width / 2) - (200 / 2), height / 7 + 5 * 24).size(200, 20).build())
     }
 
     private fun elytraMessage(enabled: Boolean) = ScreenTexts.composeToggleText(Text.translatable("options.capes.elytra"), enabled)
-
 }

--- a/common/src/main/kotlin/me/cael/capes/render/PlaceholderEntity.kt
+++ b/common/src/main/kotlin/me/cael/capes/render/PlaceholderEntity.kt
@@ -47,7 +47,7 @@ object PlaceholderEntity {
     fun getCapeTexture(): Identifier? {
         if (!capeLoaded) {
             capeLoaded = true
-            PlayerHandler.onLoadTexture(gameProfile)
+            PlayerHandler.downloadTextures(gameProfile)
         }
         val handler = PlayerHandler.fromProfile(gameProfile)
         return if (handler.hasCape) handler.getCape() else skin.capeTexture

--- a/common/src/main/resources/capes-common.mixins.json
+++ b/common/src/main/resources/capes-common.mixins.json
@@ -6,8 +6,10 @@
   "mixins": [
   ],
   "client": [
+    "KeyAccessor",
     "MixinCapeFeatureRenderer",
     "MixinPlayerListEntry",
+    "MixinPlayerSkinProvider",
     "MixinSkinOptionsScreen"
   ],
   "injectors": {


### PR DESCRIPTION
In `MixinPlayerListEntry`, rather than making a new `SkinTextures` instance each time skin textures are requested, we cache an instance of our modified `SkinTextures` to supply. This requires us to refresh the list entry when we make a change (e.g. vanilla skin finished loading), which is handled in `ListEntryAccessor`. Lastly, this also makes the toggle menu and client cape type update instantly in-game, instead of having to leave and rejoin. This also removes the bug fix in `CapeFeatureRenderer`, as this is now fixed in vanilla.