### PR TITLE
Capes for Fabric 1.21

### DIFF
--- a/common/src/main/java/me/cael/capes/mixins/MixinPlayerListEntry.java
+++ b/common/src/main/java/me/cael/capes/mixins/MixinPlayerListEntry.java
@@ -32,7 +32,7 @@ public class MixinPlayerListEntry {
             CapeConfig config = Capes.INSTANCE.getCONFIG();
             SkinTextures oldTextures = cir.getReturnValue();
             Identifier capeTexture = handler.getCape();
-            Identifier elytraTexture = handler.getHasElytraTexture() && config.getEnableElytraTexture() ? capeTexture : new Identifier("textures/entity/elytra.png");
+            Identifier elytraTexture = handler.getHasElytraTexture() && config.getEnableElytraTexture() ? capeTexture : Identifier.of("textures/entity/elytra.png");
             SkinTextures newTextures = new SkinTextures(
                     oldTextures.texture(), oldTextures.textureUrl(),
                     capeTexture, elytraTexture,

--- a/common/src/main/java/me/cael/capes/mixins/MixinSkinOptionsScreen.java
+++ b/common/src/main/java/me/cael/capes/mixins/MixinSkinOptionsScreen.java
@@ -4,8 +4,11 @@ import me.cael.capes.menu.SelectorMenu;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.option.GameOptionsScreen;
 import net.minecraft.client.gui.screen.option.SkinOptionsScreen;
+import net.minecraft.client.gui.widget.ClickableWidget;
+import net.minecraft.client.gui.widget.CyclingButtonWidget;
 import net.minecraft.client.gui.widget.TextIconButtonWidget;
 import net.minecraft.client.option.GameOptions;
+import net.minecraft.entity.player.PlayerModelPart;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 import org.spongepowered.asm.mixin.Mixin;
@@ -14,11 +17,14 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Mixin(SkinOptionsScreen.class)
 public class MixinSkinOptionsScreen extends GameOptionsScreen {
 
     @Unique
-    private static final Identifier CAPE_OPTIONS_ICON_TEXTURE = new Identifier("capes","icon/cape_options");
+    private static final Identifier CAPE_OPTIONS_ICON_TEXTURE = Identifier.of("capes","icon/cape_options");
     @Unique
     private final SelectorMenu selectorMenu = new SelectorMenu(this, this.gameOptions);
 
@@ -26,8 +32,20 @@ public class MixinSkinOptionsScreen extends GameOptionsScreen {
         super(parent, gameOptions, title);
     }
 
-    @Inject(method = "init", at = @At("RETURN"))
-    protected void init(CallbackInfo info) {
+    @Override
+    public void addOptions() {
+        List<ClickableWidget> list = new ArrayList<>();
+        PlayerModelPart[] var2 = PlayerModelPart.values();
+
+        for (PlayerModelPart playerModelPart : var2) {
+            list.add(CyclingButtonWidget.onOffBuilder(this.gameOptions.isPlayerModelPartEnabled(playerModelPart)).build(playerModelPart.getOptionName(), (cyclingButtonWidget, boolean_) -> {
+                this.gameOptions.togglePlayerModelPart(playerModelPart, boolean_);
+            }));
+        }
+
+        list.add(this.gameOptions.getMainArm().createWidget(this.gameOptions));
+        this.body.addAll(list);
         this.addDrawableChild(TextIconButtonWidget.builder(Text.empty(), (buttonWidget) -> this.client.setScreen(selectorMenu), true).dimension(20, 20).texture(CAPE_OPTIONS_ICON_TEXTURE, 16, 16).build()).setPosition(this.width / 2 - 179, this.height / 6);
+
     }
 }

--- a/common/src/main/kotlin/me/cael/capes/Capes.kt
+++ b/common/src/main/kotlin/me/cael/capes/Capes.kt
@@ -44,6 +44,6 @@ object Capes {
         finalConfig
     }
 
-    fun identifier(id: String) = Identifier(MOD_ID, id)
+    fun identifier(id: String) = Identifier.of(MOD_ID, id)
 
 }

--- a/common/src/main/kotlin/me/cael/capes/menu/MainMenu.kt
+++ b/common/src/main/kotlin/me/cael/capes/menu/MainMenu.kt
@@ -31,6 +31,10 @@ open class MainMenu(parent: Screen, gameOptions: GameOptions) : GameOptionsScree
 
     }
 
+    override fun addOptions() {
+        TODO("Not yet implemented")
+    }
+
     override fun render(context: DrawContext, mouseX: Int, mouseY: Int, delta: Float) {
         this.renderBackground(context, mouseX, mouseY, delta)
         context.drawCenteredTextWithShadow(textRenderer, title, width / 2, 20, 16777215)

--- a/common/src/main/kotlin/me/cael/capes/render/DisplayPlayerEntityRenderer.kt
+++ b/common/src/main/kotlin/me/cael/capes/render/DisplayPlayerEntityRenderer.kt
@@ -6,7 +6,6 @@ import net.minecraft.client.render.RenderLayer
 import net.minecraft.client.render.VertexConsumerProvider
 import net.minecraft.client.render.entity.EntityRendererFactory
 import net.minecraft.client.render.entity.LivingEntityRenderer
-import net.minecraft.client.render.entity.PlayerModelPart
 import net.minecraft.client.render.entity.model.ElytraEntityModel
 import net.minecraft.client.render.entity.model.EntityModelLayers
 import net.minecraft.client.render.entity.model.PlayerEntityModel
@@ -14,6 +13,7 @@ import net.minecraft.client.render.item.ItemRenderer
 import net.minecraft.client.util.DefaultSkinHelper
 import net.minecraft.client.util.math.MatrixStack
 import net.minecraft.entity.LivingEntity
+import net.minecraft.entity.player.PlayerModelPart
 import net.minecraft.util.Identifier
 import net.minecraft.util.math.MathHelper
 import net.minecraft.util.math.RotationAxis
@@ -54,7 +54,7 @@ class DisplayPlayerEntityRenderer(val ctx: EntityRendererFactory.Context, slim: 
             val renderLayer = this.model.getLayer(PlaceholderEntity.getSkinTexture())
             val vertexConsumer = vertexConsumerProvider.getBuffer(renderLayer)
             val overlay = OverlayTexture.packUv(OverlayTexture.getU(0f), OverlayTexture.getV(false))
-            model.render(matrixStack, vertexConsumer, light, overlay, 1.0f, 1.0f, 1.0f, 1.0f)
+            model.render(matrixStack, vertexConsumer, light, overlay)
         }
 
         if (!PlaceholderEntity.showElytra) {
@@ -76,8 +76,8 @@ class DisplayPlayerEntityRenderer(val ctx: EntityRendererFactory.Context, slim: 
 
             this.model.copyStateTo(this.elytra)
 
-            val vertexConsumer = ItemRenderer.getArmorGlintConsumer(vertexConsumerProvider, RenderLayer.getArmorCutoutNoCull(identifier), false, false)
-            this.elytra.render(matrixStack, vertexConsumer, light, OverlayTexture.DEFAULT_UV, 1.0f, 1.0f, 1.0f, 1.0f)
+            val vertexConsumer = ItemRenderer.getArmorGlintConsumer(vertexConsumerProvider, RenderLayer.getArmorCutoutNoCull(identifier), false)
+            this.elytra.render(matrixStack, vertexConsumer, light, OverlayTexture.DEFAULT_UV)
             matrixStack.pop()
         }
 

--- a/common/src/main/kotlin/me/cael/capes/render/PlaceholderEntity.kt
+++ b/common/src/main/kotlin/me/cael/capes/render/PlaceholderEntity.kt
@@ -56,7 +56,7 @@ object PlaceholderEntity {
     fun getElytraTexture(): Identifier {
         val handler = PlayerHandler.fromProfile(gameProfile)
         val capeTexture = getCapeTexture()
-        return if (handler.hasElytraTexture && Capes.CONFIG.enableElytraTexture && capeTexture != null) capeTexture else Identifier("textures/entity/elytra.png")
+        return if (handler.hasElytraTexture && Capes.CONFIG.enableElytraTexture && capeTexture != null) capeTexture else Identifier.of("textures/entity/elytra.png")
     }
 
     fun getSkinTexture(): Identifier = skin.texture

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,22 +1,22 @@
 org.gradle.jvmargs=-Xmx8G
 
-minecraft_version=1.20.5
-yarn_mappings=1.20.5+build.1
+minecraft_version=1.21
+yarn_mappings=1.21+build.1
 enabled_platforms=fabric
 
 archives_base_name=capes
-mod_version=1.5.4+1.20.5
+mod_version=1.5.4+1.21
 maven_group=me.capes
 
-fabric_loader_version=0.15.10
-fabric_api_version=0.97.6+1.20.5
+fabric_loader_version=0.15.11
+fabric_api_version=0.100.1+1.21
 
-forge_version=20.5.3-beta
+forge_version=21.0.0-beta
 
 # Other APIs
-fabric_kotlin_version=1.10.19+kotlin.1.9.23
+fabric_kotlin_version=1.11.0+kotlin.2.0.0
 forge_kotlin_version=4.+
-modmenu_version=10.+
+modmenu_version=11.+
 
 # Publishing
 curseforge_id=408481

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,6 +9,6 @@ pluginManagement {
 
 include("common")
 include("fabric")
-include("forge")
+//include("forge")
 
 rootProject.name = "Capes"


### PR DESCRIPTION
This is a port of Capes for 1.21. This currently only supports Fabric, as Architectury's NeoForge Yarn mappings aren't yet updated for 1.21.