### PR TITLE
Fix Malformed/invalid Game Profile JSONs from crashing the game

### DIFF
--- a/common/src/main/java/me/cael/capes/mixins/MixinPlayerListEntry.java
+++ b/common/src/main/java/me/cael/capes/mixins/MixinPlayerListEntry.java
@@ -2,6 +2,7 @@ package me.cael.capes.mixins;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
 import com.mojang.authlib.GameProfile;
 import com.mojang.authlib.properties.Property;
 import me.cael.capes.CapeConfig;
@@ -58,8 +59,15 @@ public abstract class MixinPlayerListEntry {
 
         String textures = property.get().value();
         String json = new String(Base64.getDecoder().decode(textures), StandardCharsets.UTF_8);
-        JsonElement element = JsonParser.parseString(json).getAsJsonObject().get("profileName");
-        if (element == null) return false;
+        JsonElement root;
+        try {
+            root = JsonParser.parseString(json);
+        } catch (JsonSyntaxException e) {
+            return false;
+        }
+        if (!root.isJsonObject()) return false;
+        JsonElement element = root.getAsJsonObject().get("profileName");
+        if (element == null || element.isJsonNull()) return false;
 
         String profileName = element.getAsString();
         return profile.getId().version() == 4 || (profile.getId().version() == 2 && profile.getName().equals(profileName));


### PR DESCRIPTION
I was experiencing my game crashing when doing the following:

1. Log on pvp.land:35565
2. Enter the Arena
3. Queue a practice bot with any gamemode
4. Without this change, the game would crash.

Presumably, the practice bots on this server had a malformed game profile. You can see one of the crashes I had [here](https://mclo.gs/pA6X3i6)


To address this:

- Wrapped `JsonParser.parseString(json)` in a try/catch to catch and exit on malformed JSON.
- Added a check for `root.isJsonObject()` before calling `getAsJsonObject()`.
- Guarded against missing or explicitly `null` `"profileName"` by verifying `element != null && !element.isJsonNull()`.
- Ensures that invalid or missing `"profileName"` fields no longer trigger runtime errors.