### PR TITLE
Update MCC Support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ allprojects {
         // for more information about repositories.
         maven { url 'https://jitpack.io' }
         maven { url 'https://maven.terraformersmc.com/'}
+        maven { url 'https://maven.covers1624.net/' }
     }
 
     tasks.withType(JavaCompile) {

--- a/common/src/main/kotlin/me/cael/capes/handler/PlayerHandler.kt
+++ b/common/src/main/kotlin/me/cael/capes/handler/PlayerHandler.kt
@@ -116,8 +116,13 @@ class PlayerHandler(var profile: GameProfile) {
         connection.connect()
         if (connection.responseCode / 100 == 2) {
             val reader: Reader = InputStreamReader(connection.inputStream, "UTF-8")
-            val result = Gson().fromJson(reader, MCMData::class.java)
-            return setCapeTextureFromBase64(result.textures["cape"], result.animatedCape)
+            val profile = Gson().fromJson(reader, MCMData::class.java)
+
+            val result = connection(profile.cape_url)
+            result.connect();
+            if(result.responseCode / 100 == 2) {
+                return setCapeTexture(result.inputStream, profile.animated_cape_url != null, false)
+            }
         }
         return false
     }

--- a/common/src/main/kotlin/me/cael/capes/handler/data/MCMData.kt
+++ b/common/src/main/kotlin/me/cael/capes/handler/data/MCMData.kt
@@ -1,3 +1,3 @@
 package me.cael.capes.handler.data
 
-data class MCMData(val animatedCape: Boolean = false, val textures: Map<String, String?>)
+data class MCMData(val cape_url: String, val animated_cape_url: String)

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -32,10 +32,21 @@ dependencies {
 
 //    modImplementation "com.terraformersmc:modmenu:${rootProject.modmenu_version}"
 
-    modImplementation "com.ptsmods:devlogin:3.5"
+    localRuntime 'net.covers1624:DevLogin:0.1.0.5'
 
     common(project(path: ":common", configuration: "namedElements")) { transitive false }
     shadowCommon(project(path: ":common", configuration: "transformProductionFabric")) { transitive false }
+}
+
+loom {
+    runs {
+        clientLogin {
+            client()
+            ideConfigGenerated true
+            mainClass.set 'net.covers1624.devlogin.DevLogin'
+            programArgs '--launch_target', 'net.fabricmc.loader.impl.launch.knot.KnotClient'
+        }
+    }
 }
 
 processResources {

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -21,6 +21,15 @@ architectury {
 
 loom {
     accessWidenerPath = project(":common").loom.accessWidenerPath
+
+    runs {
+        clientLogin {
+            client()
+            ideConfigGenerated true
+            mainClass.set 'net.covers1624.devlogin.DevLogin'
+            programArgs '--launch_target', 'net.minecraftforge.bootstrap.ForgeBootstrap'
+        }
+    }
 }
 
 configurations {
@@ -50,7 +59,7 @@ dependencies {
 
     implementation "thedarkcolour:kotlinforforge-neoforge:${forge_kotlin_version}"
 
-    modImplementation "com.ptsmods:devlogin:3.5"
+    localRuntime 'net.covers1624:DevLogin:0.1.0.5'
 }
 
 processResources {


### PR DESCRIPTION
Updates MinecraftCapes support by utilising the `cape_url` and `animated_cape_url` field as the textures base64 strings are deprecated.

Also added `net.covers1624:DevLogin` and removed the old `com.ptsmods:devlogin` to make development easier. 

[https://api.minecraftcapes.net/profile/ba4161c03a42496c8ae07d13372f3371](https://api.minecraftcapes.net/profile/ba4161c03a42496c8ae07d13372f3371)

Announcement here in MinecraftCapes discord: https://discord.com/channels/238799720787476481/257175877979340801/1442321924347793418